### PR TITLE
Change duplicate package status code to 403

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -35,7 +35,7 @@ function register(name, url, callback) {
         }
 
         // Duplicate
-        if (response.statusCode === 406) {
+        if (response.statusCode === 403) {
             return callback(createError('Duplicate package', 'EDUPLICATE'));
         }
 


### PR DESCRIPTION
Registry no longer sends 406 (since bower/registry@74ae4d34b) so clients would previously just see "Unknown error: 403 if they tried to register a duplicate package.