### PR TITLE
Fix error bower command behind proxy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bower-config": "~0.5.0",
     "graceful-fs": "~2.0.0",
     "lru-cache": "~2.3.0",
-    "request": "~2.27.0",
+    "request": "~2.51.0",
     "request-replay": "~0.2.0",
     "rimraf": "~2.2.0",
     "mkdirp": "~0.3.5"


### PR DESCRIPTION
Fails bower install, bower lookup, etc, behind proxy with Node.js 0.11.15.

```
$ node --version
v0.11.15
$ bower --version
1.3.12
$ bower cache clean && bower install underscore
_http_client.js:73
    throw new TypeError('Request path contains unescaped characters.');
          ^
TypeError: Request path contains unescaped characters.
    at new ClientRequest (_http_client.js:73:11)
    at TunnelingAgent.exports.request (http.js:49:10)
    at TunnelingAgent.createSocket (/home/masakura/.nvm/v0.11.15/lib/node_modules/bower/node_modules/bower-registry-client/node_modules/request/node_modules/tunnel-agent/index.js:117:25)
    at TunnelingAgent.createSecureSocket [as createSocket] (/home/masakura/.nvm/v0.11.15/lib/node_modules/bower/node_modules/bower-registry-client/node_modules/request/node_modules/tunnel-agent/index.js:184:41)
    at TunnelingAgent.addRequest (/home/masakura/.nvm/v0.11.15/lib/node_modules/bower/node_modules/bower-registry-client/node_modules/request/node_modules/tunnel-agent/index.js:80:8)
    at new ClientRequest (_http_client.js:154:16)
    at Object.exports.request (http.js:49:10)
    at Object.exports.request (https.js:136:15)
    at Request.start (/home/masakura/.nvm/v0.11.15/lib/node_modules/bower/node_modules/bower-registry-client/node_modules/request/request.js:584:30)
    at Request.end (/home/masakura/.nvm/v0.11.15/lib/node_modules/bower/node_modules/bower-registry-client/node_modules/request/request.js:1212:28)
```

It seems this problem occurs with a combination of request@2.27.0 and Node.js 0.11.15. It resolved by use request@2.51.0.